### PR TITLE
Rijkschat link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We werken aan de volgende innovatie [thema's](https://ssc-ict-innovatie.nl/2018/
 ## Projecten 2018
  * [Keteninformatie](https://rijksgithub.nl/SSC-ICT-Innovatie/Keteninformatie)
  * [On-The-Move](https://on-the-move.ml)
- * [Rijkschat](https://rijkchat.nl)
+ * [Rijkschat](https://rijkschat.nl)
  * [Rijksgithub](https://rijksgithub.nl)
  * Smartbuilding programma
  


### PR DESCRIPTION
De link naar de Rijkschat is niet goed. Hierbij de juiste link.